### PR TITLE
Add WebForms chatbot skeleton

### DIFF
--- a/ChatBot.sln
+++ b/ChatBot.sln
@@ -1,0 +1,11 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatBot", "src/ChatBot/ChatBot.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatBot.Tests", "tests/ChatBot.Tests.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Global
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # New-App-Chat-Bot
+
+This repository contains a minimal sample project for a C# chat bot using the OpenAI API. The project is built with **ASP.NET WebForms** targeting **.NET Framework 4.8** and demonstrates how to:
+
+- Configure different OpenAI models and API keys via an admin panel (protected by HTTP Basic authentication)
+- Persist chat history and API responses in a SQLite database
+- Configure Google OAuth credentials from the admin panel and initiate login
+- View raw chat logs and errors through a debug page
+
+For a detailed plan and folder structure see [docs/project-plan.md](docs/project-plan.md).
+
+> **Note**: The implementation is intentionally lightweight and serves as a starting point. Some parts (e.g. Google OAuth flow) are provided as placeholders.
+

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1,0 +1,77 @@
+# Project Plan: Chat Bot Web Application
+
+## Overview
+
+This project is a minimal web application built with **ASP.NET WebForms (.NET Framework 4.8)**. It exposes a simple chat bot using the OpenAI API. An admin panel allows management of the API key, model selection and Google OAuth credentials. The panel is protected by HTTP Basic authentication. SQLite is used for storage. Chat logs and API responses are saved for debugging. A debug screen displays stored logs and errors.
+
+## Goals
+
+1. Self-contained ASP.NET WebForms site targeting .NET Framework 4.8.
+2. SQLite database automatically created on application start if missing.
+3. Admin panel with configuration for API key, model and Google OAuth credentials.
+4. Admin panel protected via basic authentication.
+5. Login via Google OAuth.
+6. Chat page to interact with OpenAI.
+7. Debug page showing raw JSON chat logs and errors.
+8. Unit tests for core modules.
+
+## Architecture
+
+The application follows SOLID principles with small classes:
+
+- `DbManager` handles database creation and queries.
+- `OpenAIService` wraps calls to the OpenAI API.
+- `AuthManager` provides Google OAuth integration (simplified placeholder).
+- `ErrorLogger` persists application errors.
+- WebForms pages (`.aspx`) interact with these services.
+
+## Folder Structure
+
+```
+/ (repo root)
+├─ README.md
+├─ docs/
+│  └─ project-plan.md
+├─ src/
+│  └─ ChatBot/
+│     ├─ ChatBot.csproj
+│     ├─ Global.asax
+│     ├─ Web.config
+│     ├─ App_Code/
+│     │  ├─ DbManager.cs
+│     │  ├─ OpenAIService.cs
+│     │  ├─ ErrorLogger.cs
+│     │  └─ AuthManager.cs
+│     ├─ Admin/
+│     │  ├─ Admin.aspx
+│     │  └─ Admin.aspx.cs
+│     ├─ Chat/
+│     │  ├─ Chat.aspx
+│     │  └─ Chat.aspx.cs
+│     ├─ Debug/
+│     │  ├─ Debug.aspx
+│     │  └─ Debug.aspx.cs
+│     └─ Login.aspx
+├─ tests/
+│  ├─ ChatBot.Tests.csproj
+│  ├─ DbManagerTests.cs
+│  └─ OpenAIServiceTests.cs
+```
+
+## Development Tasks
+
+1. **Create SQLite helper**: builds DB with tables `Config`, `Chats`, `Errors` and inserts default admin credentials.
+2. **Implement OpenAI service**: simple POST request to OpenAI API.
+3. **Admin panel**: update configuration for API key, model and Google OAuth credentials. Protect the page with basic auth.
+4. **Login page**: integrate Google OAuth (outline code only).
+5. **Chat page**: send messages and display responses.
+6. **Debug page**: show chat logs and errors in JSON format.
+7. **Unit tests**: verify DB creation and API calls (mocked).
+8. **Documentation**: keep README and doc files up to date.
+
+## Notes
+
+- This repository contains skeleton code suitable for extending. Some implementation details (e.g. Google OAuth flow) are placeholders and require completion in a real environment.
+- The solution targets **.NET Framework 4.8**, which requires a Windows build environment.
+- Bootstrap is included via CDN for styling.
+

--- a/src/ChatBot/Admin/Admin.aspx
+++ b/src/ChatBot/Admin/Admin.aspx
@@ -1,0 +1,39 @@
+<%@ Page Language="C#" AutoEventWireup="true" CodeBehind="Admin.aspx.cs" Inherits="ChatBot.Admin.Admin" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Admin</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" />
+</head>
+<body class="container mt-4">
+    <h1>Admin Configuration</h1>
+    <form runat="server" class="mb-3">
+        <div class="mb-3">
+            <label for="ApiKey">API Key</label>
+            <asp:TextBox ID="ApiKey" runat="server" CssClass="form-control" />
+        </div>
+        <div class="mb-3">
+            <label for="Model">Model</label>
+            <asp:TextBox ID="Model" runat="server" CssClass="form-control" />
+        </div>
+        <div class="mb-3">
+            <label for="GoogleClientId">Google Client ID</label>
+            <asp:TextBox ID="GoogleClientId" runat="server" CssClass="form-control" />
+        </div>
+        <div class="mb-3">
+            <label for="GoogleClientSecret">Google Client Secret</label>
+            <asp:TextBox ID="GoogleClientSecret" runat="server" CssClass="form-control" TextMode="Password" />
+        </div>
+        <div class="mb-3">
+            <label for="AdminUser">Admin Username</label>
+            <asp:TextBox ID="AdminUser" runat="server" CssClass="form-control" />
+        </div>
+        <div class="mb-3">
+            <label for="AdminPassword">Admin Password</label>
+            <asp:TextBox ID="AdminPassword" runat="server" CssClass="form-control" TextMode="Password" />
+        </div>
+        <asp:Button ID="SaveButton" runat="server" Text="Save" CssClass="btn btn-primary" OnClick="SaveButton_Click" />
+    </form>
+    <a href="../Chat/Chat.aspx">Go to Chat</a>
+</body>
+</html>

--- a/src/ChatBot/Admin/Admin.aspx.cs
+++ b/src/ChatBot/Admin/Admin.aspx.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Data.SQLite;
+using System.Text;
+
+namespace ChatBot.Admin
+{
+    public partial class Admin : System.Web.UI.Page
+    {
+        protected void Page_Load(object sender, EventArgs e)
+        {
+            App_Code.DbManager.Initialize();
+            if (!Authenticate())
+            {
+                Response.StatusCode = 401;
+                Response.AddHeader("WWW-Authenticate", "Basic realm=\"Admin\"");
+                Response.End();
+                return;
+            }
+
+            if (!IsPostBack)
+            {
+                using var conn = App_Code.DbManager.GetConnection();
+                var cmd = conn.CreateCommand();
+                cmd.CommandText = "SELECT ApiKey, Model, GoogleClientId, GoogleClientSecret, AdminUser, AdminPassword FROM Config WHERE Id = 1";
+                using var reader = cmd.ExecuteReader();
+                if (reader.Read())
+                {
+                    ApiKey.Text = reader.GetString(0);
+                    Model.Text = reader.GetString(1);
+                    GoogleClientId.Text = reader.GetString(2);
+                    GoogleClientSecret.Text = reader.GetString(3);
+                    AdminUser.Text = reader.GetString(4);
+                    AdminPassword.Text = reader.GetString(5);
+                }
+            }
+        }
+
+        private bool Authenticate()
+        {
+            string auth = Request.Headers["Authorization"];
+            if (!string.IsNullOrEmpty(auth) && auth.StartsWith("Basic "))
+            {
+                string encoded = auth.Substring("Basic ".Length).Trim();
+                string decoded = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+                var parts = decoded.Split(':');
+                if (parts.Length == 2)
+                {
+                    string user = parts[0];
+                    string pass = parts[1];
+                    using var conn = App_Code.DbManager.GetConnection();
+                    var cmd = conn.CreateCommand();
+                    cmd.CommandText = "SELECT AdminUser, AdminPassword FROM Config WHERE Id = 1";
+                    using var reader = cmd.ExecuteReader();
+                    if (reader.Read())
+                    {
+                        return user == reader.GetString(0) && pass == reader.GetString(1);
+                    }
+                }
+            }
+            return false;
+        }
+
+        protected void SaveButton_Click(object sender, EventArgs e)
+        {
+            using var conn = App_Code.DbManager.GetConnection();
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "REPLACE INTO Config(Id, ApiKey, Model, GoogleClientId, GoogleClientSecret, AdminUser, AdminPassword) VALUES(1, @k, @m, @cid, @sec, @user, @pass)";
+            cmd.Parameters.AddWithValue("@k", ApiKey.Text);
+            cmd.Parameters.AddWithValue("@m", Model.Text);
+            cmd.Parameters.AddWithValue("@cid", GoogleClientId.Text);
+            cmd.Parameters.AddWithValue("@sec", GoogleClientSecret.Text);
+            cmd.Parameters.AddWithValue("@user", AdminUser.Text);
+            cmd.Parameters.AddWithValue("@pass", AdminPassword.Text);
+            cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/src/ChatBot/App_Code/AuthManager.cs
+++ b/src/ChatBot/App_Code/AuthManager.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Web;
+
+namespace App_Code
+{
+    public static class AuthManager
+    {
+        // Simplified Google OAuth redirect using configured client ID
+        public static void SignIn(HttpResponse response)
+        {
+            string clientId = string.Empty;
+            using (var conn = DbManager.GetConnection())
+            {
+                var cmd = conn.CreateCommand();
+                cmd.CommandText = "SELECT GoogleClientId FROM Config WHERE Id = 1";
+                using var reader = cmd.ExecuteReader();
+                if (reader.Read())
+                {
+                    clientId = reader.GetString(0);
+                }
+            }
+
+            // TODO: implement full OAuth flow and token handling
+            var redirectUri = HttpUtility.UrlEncode("/Login.aspx");
+            var url = $"https://accounts.google.com/o/oauth2/auth?client_id={clientId}&redirect_uri={redirectUri}&response_type=code&scope=openid%20email";
+            response.Redirect(url);
+        }
+    }
+}

--- a/src/ChatBot/App_Code/DbManager.cs
+++ b/src/ChatBot/App_Code/DbManager.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Data.SQLite;
+using System.IO;
+
+namespace App_Code
+{
+    public static class DbManager
+    {
+        private static readonly string DbPath = Path.Combine(AppDomain.CurrentDomain.GetData("DataDirectory").ToString(), "chatbot.db");
+        private const string ConnectionString = "Data Source=" + "|DataDirectory|chatbot.db";
+
+        public static void Initialize()
+        {
+            Directory.CreateDirectory(AppDomain.CurrentDomain.GetData("DataDirectory").ToString());
+            if (!File.Exists(DbPath))
+            {
+                SQLiteConnection.CreateFile(DbPath);
+                using var conn = new SQLiteConnection(ConnectionString);
+                conn.Open();
+                var cmd = conn.CreateCommand();
+                cmd.CommandText = @"CREATE TABLE Config(
+                                        Id INTEGER PRIMARY KEY,
+                                        ApiKey TEXT,
+                                        Model TEXT,
+                                        GoogleClientId TEXT,
+                                        GoogleClientSecret TEXT,
+                                        AdminUser TEXT,
+                                        AdminPassword TEXT);
+                                    CREATE TABLE Chats(Id INTEGER PRIMARY KEY AUTOINCREMENT, UserId TEXT, Message TEXT, ResponseJson TEXT, CreatedAt DATETIME);
+                                    CREATE TABLE Errors(Id INTEGER PRIMARY KEY AUTOINCREMENT, Message TEXT, StackTrace TEXT, CreatedAt DATETIME);";
+                cmd.ExecuteNonQuery();
+
+                cmd.CommandText = @"INSERT INTO Config(Id, ApiKey, Model, GoogleClientId, GoogleClientSecret, AdminUser, AdminPassword)
+                                    VALUES(1, '', 'gpt-3.5-turbo', '', '', 'admin', 'password');";
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        public static SQLiteConnection GetConnection()
+        {
+            var conn = new SQLiteConnection(ConnectionString);
+            conn.Open();
+            return conn;
+        }
+    }
+}

--- a/src/ChatBot/App_Code/ErrorLogger.cs
+++ b/src/ChatBot/App_Code/ErrorLogger.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Data.SQLite;
+
+namespace App_Code
+{
+    public static class ErrorLogger
+    {
+        public static void Log(Exception ex)
+        {
+            using var conn = DbManager.GetConnection();
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO Errors(Message, StackTrace, CreatedAt) VALUES(@m, @s, @c)";
+            cmd.Parameters.AddWithValue("@m", ex.Message);
+            cmd.Parameters.AddWithValue("@s", ex.StackTrace);
+            cmd.Parameters.AddWithValue("@c", DateTime.UtcNow);
+            cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/src/ChatBot/App_Code/OpenAIService.cs
+++ b/src/ChatBot/App_Code/OpenAIService.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace App_Code
+{
+    public class OpenAIService
+    {
+        private readonly string _apiKey;
+        private readonly string _model;
+
+        public OpenAIService(string apiKey, string model)
+        {
+            _apiKey = apiKey;
+            _model = model;
+        }
+
+        public async Task<string> SendMessageAsync(string message)
+        {
+            using var client = new HttpClient();
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {_apiKey}");
+
+            var payload = new JObject
+            {
+                ["model"] = _model,
+                ["messages"] = new JArray
+                {
+                    new JObject { ["role"] = "user", ["content"] = message }
+                }
+            };
+
+            var content = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
+            var response = await client.PostAsync("https://api.openai.com/v1/chat/completions", content);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
+        }
+    }
+}

--- a/src/ChatBot/Chat/Chat.aspx
+++ b/src/ChatBot/Chat/Chat.aspx
@@ -1,0 +1,20 @@
+<%@ Page Language="C#" AutoEventWireup="true" CodeBehind="Chat.aspx.cs" Inherits="ChatBot.Chat.ChatPage" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Chat</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" />
+</head>
+<body class="container mt-4">
+    <h1>Chat</h1>
+    <form runat="server" class="mb-3">
+        <div class="mb-3">
+            <asp:TextBox ID="UserMessage" runat="server" CssClass="form-control" />
+        </div>
+        <asp:Button ID="SendButton" runat="server" Text="Send" CssClass="btn btn-primary" OnClick="SendButton_Click" />
+    </form>
+    <pre id="Response" runat="server"></pre>
+    <a href="../Admin/Admin.aspx">Admin</a> |
+    <a href="../Debug/Debug.aspx">Debug</a>
+</body>
+</html>

--- a/src/ChatBot/Chat/Chat.aspx.cs
+++ b/src/ChatBot/Chat/Chat.aspx.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Data.SQLite;
+using System.Web.UI;
+using App_Code;
+
+namespace ChatBot.Chat
+{
+    public partial class ChatPage : Page
+    {
+        protected async void SendButton_Click(object sender, EventArgs e)
+        {
+            string apiKey = string.Empty;
+            string model = string.Empty;
+            using (var conn = DbManager.GetConnection())
+            {
+                var cmd = conn.CreateCommand();
+                cmd.CommandText = "SELECT ApiKey, Model FROM Config WHERE Id = 1";
+                using var reader = cmd.ExecuteReader();
+                if (reader.Read())
+                {
+                    apiKey = reader.GetString(0);
+                    model = reader.GetString(1);
+                }
+            }
+
+            var service = new OpenAIService(apiKey, model);
+            try
+            {
+                var json = await service.SendMessageAsync(UserMessage.Text);
+                Response.InnerText = json;
+
+                using var conn = DbManager.GetConnection();
+                var cmd = conn.CreateCommand();
+                cmd.CommandText = "INSERT INTO Chats(UserId, Message, ResponseJson, CreatedAt) VALUES(@u, @m, @r, @c)";
+                cmd.Parameters.AddWithValue("@u", User.Identity.Name ?? "anon");
+                cmd.Parameters.AddWithValue("@m", UserMessage.Text);
+                cmd.Parameters.AddWithValue("@r", json);
+                cmd.Parameters.AddWithValue("@c", DateTime.UtcNow);
+                cmd.ExecuteNonQuery();
+            }
+            catch (Exception ex)
+            {
+                ErrorLogger.Log(ex);
+                Response.InnerText = "Error: " + ex.Message;
+            }
+        }
+    }
+}

--- a/src/ChatBot/ChatBot.csproj
+++ b/src/ChatBot/ChatBot.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Data.SQLite" Version="1.0.115" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.60.0" />
+  </ItemGroup>
+</Project>

--- a/src/ChatBot/Debug/Debug.aspx
+++ b/src/ChatBot/Debug/Debug.aspx
@@ -1,0 +1,13 @@
+<%@ Page Language="C#" AutoEventWireup="true" CodeBehind="Debug.aspx.cs" Inherits="ChatBot.Debug.DebugPage" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Debug</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" />
+</head>
+<body class="container mt-4">
+    <h1>Debug Logs</h1>
+    <pre id="Logs" runat="server" style="height:400px;overflow:auto;"></pre>
+    <a href="../Chat/Chat.aspx">Back to Chat</a>
+</body>
+</html>

--- a/src/ChatBot/Debug/Debug.aspx.cs
+++ b/src/ChatBot/Debug/Debug.aspx.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Data.SQLite;
+using System.Text;
+using System.Web.UI;
+using App_Code;
+
+namespace ChatBot.Debug
+{
+    public partial class DebugPage : Page
+    {
+        protected void Page_Load(object sender, EventArgs e)
+        {
+            var sb = new StringBuilder();
+            using var conn = DbManager.GetConnection();
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT Message, ResponseJson, CreatedAt FROM Chats ORDER BY CreatedAt DESC";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                sb.AppendLine(reader.GetString(0));
+                sb.AppendLine(reader.GetString(1));
+                sb.AppendLine(reader.GetDateTime(2).ToString());
+                sb.AppendLine("---");
+            }
+
+            cmd.CommandText = "SELECT Message, StackTrace, CreatedAt FROM Errors ORDER BY CreatedAt DESC";
+            using var er = cmd.ExecuteReader();
+            sb.AppendLine("Errors:");
+            while (er.Read())
+            {
+                sb.AppendLine(er.GetString(0));
+                sb.AppendLine(er.GetString(1));
+                sb.AppendLine(er.GetDateTime(2).ToString());
+                sb.AppendLine("---");
+            }
+
+            Logs.InnerText = sb.ToString();
+        }
+    }
+}

--- a/src/ChatBot/Global.asax
+++ b/src/ChatBot/Global.asax
@@ -1,0 +1,7 @@
+<%@ Application Language="C#" %>
+<script runat="server">
+    void Application_Start(object sender, EventArgs e)
+    {
+        App_Code.DbManager.Initialize();
+    }
+</script>

--- a/src/ChatBot/Login.aspx
+++ b/src/ChatBot/Login.aspx
@@ -1,0 +1,18 @@
+<%@ Page Language="C#" AutoEventWireup="true" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+</head>
+<body>
+    <form runat="server">
+        <asp:Button ID="LoginButton" runat="server" Text="Login with Google" OnClick="LoginButton_Click" />
+    </form>
+</body>
+</html>
+<script runat="server">
+    protected void LoginButton_Click(object sender, EventArgs e)
+    {
+        App_Code.AuthManager.SignIn(Response);
+    }
+</script>

--- a/src/ChatBot/Web.config
+++ b/src/ChatBot/Web.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.web>
+    <compilation debug="true" targetFramework="4.8" />
+    <httpRuntime targetFramework="4.8" />
+    <authentication mode="None" />
+  </system.web>
+</configuration>

--- a/src/ChatBot/packages.config
+++ b/src/ChatBot/packages.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Data.SQLite" version="1.0.115" targetFramework="net48" />
+  <package id="Google.Apis.Auth" version="1.60.0" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+</packages>

--- a/tests/ChatBot.Tests.csproj
+++ b/tests/ChatBot.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <ProjectReference Include="..\src\ChatBot\ChatBot.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/DbManagerTests.cs
+++ b/tests/DbManagerTests.cs
@@ -1,0 +1,18 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using App_Code;
+
+namespace ChatBot.Tests
+{
+    [TestClass]
+    public class DbManagerTests
+    {
+        [TestMethod]
+        public void Initialize_CreatesDatabase()
+        {
+            DbManager.Initialize();
+            var path = Path.Combine(System.AppDomain.CurrentDomain.GetData("DataDirectory").ToString(), "chatbot.db");
+            Assert.IsTrue(File.Exists(path));
+        }
+    }
+}

--- a/tests/OpenAIServiceTests.cs
+++ b/tests/OpenAIServiceTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using App_Code;
+using System.Threading.Tasks;
+
+namespace ChatBot.Tests
+{
+    [TestClass]
+    public class OpenAIServiceTests
+    {
+        [TestMethod]
+        public async Task SendMessageAsync_ReturnsJson()
+        {
+            var service = new OpenAIService("test-key", "gpt-3.5-turbo");
+            try
+            {
+                var json = await service.SendMessageAsync("Hello");
+                Assert.IsFalse(string.IsNullOrEmpty(json));
+            }
+            catch
+            {
+                Assert.Inconclusive("API call failed - requires valid key");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- outline project plan with folder structure
- add minimal README
- create ASP.NET WebForms project skeleton using SQLite
- include simple admin, chat and debug pages
- provide placeholder Google OAuth and OpenAI integration
- add MSTest test project
- add basic auth for admin and support Google OAuth configuration

## Testing
- `dotnet test` *(fails: `dotnet` not found)*