### PR TITLE
Fix build by adding .NET reference assemblies

### DIFF
--- a/src/ChatBot/ChatBot.csproj
+++ b/src/ChatBot/ChatBot.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Allow building against .NET Framework reference assemblies on any OS -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.115" />
     <PackageReference Include="Google.Apis.Auth" Version="1.60.0" />
   </ItemGroup>

--- a/tests/ChatBot.Tests.csproj
+++ b/tests/ChatBot.Tests.csproj
@@ -4,6 +4,8 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Use reference assemblies so tests build on non-Windows machines -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />


### PR DESCRIPTION
## Summary
- ensure ChatBot and test projects include `Microsoft.NETFramework.ReferenceAssemblies.net48`

## Testing
- `git log -1 --stat`