### PR TITLE
Fix .NET reference assembly downgrade warnings

### DIFF
--- a/src/ChatBot/ChatBot.csproj
+++ b/src/ChatBot/ChatBot.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Allow building against .NET Framework reference assemblies on any OS -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.115" />
     <PackageReference Include="Google.Apis.Auth" Version="1.60.0" />
   </ItemGroup>

--- a/tests/ChatBot.Tests.csproj
+++ b/tests/ChatBot.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Use reference assemblies so tests build on non-Windows machines -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />


### PR DESCRIPTION
## Summary
- update reference assembly version to 1.0.3 for ASP.NET project and unit tests

## Testing
- `dotnet restore ChatBot.sln` *(fails: `dotnet: command not found`)*
- `dotnet test ChatBot.sln` *(fails: `dotnet: command not found`)*