### PR TITLE
Fix Chat page naming and add build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,7 @@ This repository contains a minimal sample project for a C# chat bot using the Op
 
 For a detailed plan and folder structure see [docs/project-plan.md](docs/project-plan.md).
 
+> **Build Requirements**: The solution targets **.NET Framework 4.8** and must be built on Windows using Visual Studio or MSBuild. .NET CLI on Linux is insufficient.
+
 > **Note**: The implementation is intentionally lightweight and serves as a starting point. Some parts (e.g. Google OAuth flow) are provided as placeholders.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Unreleased]
+- Fixed naming conflict in `Chat.aspx` that prevented build by renaming the response `<pre>` element to `JsonResponse` and updating the code-behind.
+- Attempted to build the project but `dotnet` and `msbuild` tools were unavailable in the environment.

--- a/src/ChatBot/Chat/Chat.aspx
+++ b/src/ChatBot/Chat/Chat.aspx
@@ -13,7 +13,7 @@
         </div>
         <asp:Button ID="SendButton" runat="server" Text="Send" CssClass="btn btn-primary" OnClick="SendButton_Click" />
     </form>
-    <pre id="Response" runat="server"></pre>
+    <pre id="JsonResponse" runat="server"></pre>
     <a href="../Admin/Admin.aspx">Admin</a> |
     <a href="../Debug/Debug.aspx">Debug</a>
 </body>

--- a/src/ChatBot/Chat/Chat.aspx.cs
+++ b/src/ChatBot/Chat/Chat.aspx.cs
@@ -27,7 +27,7 @@ namespace ChatBot.Chat
             try
             {
                 var json = await service.SendMessageAsync(UserMessage.Text);
-                Response.InnerText = json;
+                JsonResponse.InnerText = json;
 
                 using var conn = DbManager.GetConnection();
                 var cmd = conn.CreateCommand();
@@ -41,7 +41,7 @@ namespace ChatBot.Chat
             catch (Exception ex)
             {
                 ErrorLogger.Log(ex);
-                Response.InnerText = "Error: " + ex.Message;
+                JsonResponse.InnerText = "Error: " + ex.Message;
             }
         }
     }


### PR DESCRIPTION
## Summary
- fix server control naming in `Chat.aspx` and update the code-behind
- add build requirement notice to README
- start a `CHANGELOG`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*