### PR TITLE
Fix build refs and update docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## [Unreleased]
 - Fixed naming conflict in `Chat.aspx` that prevented build by renaming the response `<pre>` element to `JsonResponse` and updating the code-behind.
 - Attempted to build the project but `dotnet` and `msbuild` tools were unavailable in the environment.
+- Added explicit `System.Web` reference so the WebForms project compiles with reference assemblies.
+- Updated documentation with revised project plan and deep dive analysis.

--- a/docs/deep-dive-report.md
+++ b/docs/deep-dive-report.md
@@ -1,26 +1,38 @@
-# Deep Dive Analysis
+# Deep Dive Report
 
 ## Overview
 
-This repository implements a minimal ASP.NET WebForms chat bot that calls the OpenAI API. It targets the .NET Framework 4.8 and persists configuration, chat history and error logs in SQLite. Authentication is implemented with Google OAuth (placeholder) and an admin panel secured by HTTP Basic authentication. The solution uses Bootstrap for styling and includes a small set of unit tests.
+This ASP.NET WebForms project demonstrates a lightweight chat bot that talks to the OpenAI API. It targets **.NET Framework 4.8** and stores configuration, chat transcripts and error logs inside a local SQLite database. The application uses Bootstrap for styling and exposes three pages:
 
-## Architecture and SOLID Evaluation
+- `Admin.aspx` – configuration UI protected by HTTP basic auth
+- `Chat.aspx` – user chat interface
+- `Debug.aspx` – raw log viewer for troubleshooting
 
-- **DbManager** creates the SQLite database on first run and exposes a helper to obtain open connections. It is referenced directly from WebForms pages.
-- **OpenAIService** encapsulates calls to the OpenAI API using `HttpClient`.
-- **AuthManager** contains a simplified Google OAuth initiation flow.
-- **ErrorLogger** writes exception details to the database.
-- Code-behind files such as [`Chat.aspx.cs`](../src/ChatBot/Chat/Chat.aspx.cs) mix UI logic with data access and OpenAI interaction.
+Google OAuth login is provided as a placeholder via `AuthManager`. Unit tests cover basic database initialization and the OpenAI service call.
 
-The overall design keeps classes small but does not fully embrace SOLID principles:
+## Architecture Assessment
 
-- Pages depend on static helpers, creating tight coupling. Dependency inversion is not used.
-- Database queries appear in several code-behind files violating single responsibility.
-- Extensibility is limited; for example, swapping the database requires edits throughout the pages.
+### SOLID and Separation of Concerns
 
-## Database Schema and Initialization
+- **S**ingle Responsibility – WebForms code behind files mix UI logic with data access and service calls. Classes in `App_Code` are small but pages still know about the database.
+- **O**pen/Closed – Adding a new storage mechanism or authentication provider would require edits across pages because dependencies are hard coded.
+- **L**iskov Substitution – Not directly violated but the tight coupling makes substitution difficult.
+- **I**nterface Segregation – No interfaces are defined for the services which limits mocking and testability.
+- **D**ependency Inversion – Pages create concrete service objects (`new OpenAIService`) rather than depending on abstractions.
 
-`DbManager.Initialize()` creates three tables when `chatbot.db` does not exist:
+### Extensibility and Maintainability
+
+The current design is sufficient for a demo but scaling the code base would be challenging:
+
+- Database queries are scattered through page code which complicates refactoring.
+- Static helpers and direct `HttpClient` usage hinder unit testing.
+- Lack of dependency injection prevents easy replacement or extension of services.
+
+A service/repository pattern with interfaces would better align with SOLID principles and allow dependency injection.
+
+## Database Schema and Generation
+
+The database is created on first run via `DbManager.Initialize()`:
 
 ```csharp
 cmd.CommandText = @"CREATE TABLE Config(...);
@@ -29,41 +41,35 @@ cmd.CommandText = @"CREATE TABLE Config(...);
 ```
 【F:src/ChatBot/App_Code/DbManager.cs†L17-L34】
 
-The schema stores a single configuration row and logs for chats and errors. While functional, the admin password and API key are stored in plain text. Password hashing and secret encryption are absent. Auto-generation logic relies on executing multiple SQL statements in one command, which may obscure errors during creation.
+All configuration values are stored in a single row. Admin credentials and API keys are in plain text which is insecure. Executing multiple statements in one command makes failures harder to diagnose. Adding discrete migration scripts or using an ORM would improve maintainability.
 
-## Security Assessment
+## Security Review
 
-- **OAuth** – `AuthManager.SignIn` only builds the Google authorization URL and lacks token validation or state checking. The redirect URI is hardcoded to `Login.aspx` and no CSRF protection is implemented.
-- **API Key Storage** – API keys and secrets are persisted unencrypted in the `Config` table.
-- **Admin Authorization** – `Admin.aspx.cs` performs HTTP Basic auth by comparing credentials stored in the database without hashing, exposing risk if the database is compromised.
-- **XSS/CSRF** – User input and stored logs are rendered via `<pre>` without HTML encoding (`Debug.aspx`). Forms do not use anti-forgery tokens, leaving the admin panel vulnerable to CSRF.
-
-## Maintainability and Extensibility
-
-The project uses a minimal service/repository approach. Because static helpers are accessed directly from pages, unit testing is difficult without hitting the database or real services. Introducing interfaces and dependency injection would allow mocking and better separation of concerns. The current structure may suffice for a small demo but would hinder larger feature additions.
+- **OAuth** – The sign‑in helper simply redirects to Google without validating the returned token or protecting against CSRF.
+- **API Key Storage** – Keys and passwords are saved unencrypted in SQLite.
+- **Admin Auth** – Basic authentication compares plain text credentials from the database.
+- **CSRF/XSS** – Forms lack anti‑forgery tokens and the debug page writes raw text without HTML encoding.
 
 ## Performance Considerations
 
-- Opening a new `HttpClient` per request in `OpenAIService` can lead to socket exhaustion.
-- SQLite writes are synchronous and may block under heavy load, though acceptable for small hobby deployments.
-- WebForms ViewState is minimal in the sample pages but could grow if controls are added. Disabling ViewState on static elements would reduce page size.
-- Debug logging writes synchronously inside the chat request; offloading to a background worker could improve throughput.
+- Each call to `OpenAIService.SendMessageAsync` creates a new `HttpClient`. Reusing a single instance would avoid socket exhaustion.
+- SQLite writes occur synchronously in the web request. For heavy traffic, asynchronous database APIs or a background logger would help.
+- ViewState is minimal now but can grow if more controls are added. Disable it on static controls to reduce payloads.
 
 ## Unit Testing Strategy
 
-Tests exist for database initialization and the `OpenAIService` call, but they operate on the concrete implementations. Because dependencies are static, additional business logic would be hard to test. The `OpenAIServiceTests` rely on an actual API key and mark the test inconclusive when failing. Using mockable interfaces and dependency injection would make tests deterministic.
+Tests exist for database creation and the OpenAI service. Because services are static and instantiated directly, further unit tests would require hitting the real database or network. Introducing interfaces and dependency injection would enable mocks and more reliable tests.
 
-## Recommended Enhancements
+## Recommended Improvements
 
-1. **Introduce dependency injection** to decouple WebForms pages from concrete services.
-2. **Hash admin passwords** (e.g., PBKDF2) and encrypt API keys using DPAPI or similar.
-3. **Replace basic auth** with an OAuth-based sign‑in that issues an authenticated session cookie.
-4. **Add anti‑forgery tokens and output encoding** to mitigate CSRF and XSS.
-5. **Reuse `HttpClient`** instances and consider asynchronous database APIs for scalability.
-6. **Expand unit tests** using mocks for the OpenAI API and data repositories.
-7. **Modularize data access** into repositories so other storage engines can be introduced later.
-8. **Improve logging** by including request context and rotating the log tables.
+1. Introduce dependency injection (e.g., SimpleInjector or built‑in .NET DI) so pages depend on interfaces rather than concrete helpers.
+2. Hash admin passwords and encrypt API keys using DPAPI or a similar mechanism.
+3. Replace basic auth with an OAuth‑based login that issues a secure session cookie.
+4. Add anti‑forgery tokens to forms and HTML encode output to mitigate CSRF/XSS.
+5. Use a single static `HttpClient` instance and consider async database access.
+6. Move SQL access into repository classes to separate concerns and aid unit testing.
+7. Expand unit tests with mocks for OpenAI and data repositories.
 
 ## Conclusion
 
-The project provides a concise demonstration of integrating OpenAI with ASP.NET WebForms but lacks several production‑quality practices. Applying the enhancements above would improve security, maintainability and extensibility while still keeping the implementation lightweight.
+The application is a concise demonstration of an OpenAI chat bot in WebForms. With the improvements above—particularly around dependency injection, security hardening and testability—it can evolve into a more maintainable and secure code base.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -36,6 +36,8 @@ The application follows SOLID principles with small classes:
 - Include anti-forgery tokens on all admin forms to mitigate CSRF attacks.
 - Centralize HTTP calls via `HttpClient` instances managed by dependency
   injection to improve testability and performance.
+- Add explicit references to `System.Web` so the project builds using
+  cross-platform reference assemblies.
 
 ## Folder Structure
 

--- a/src/ChatBot/Admin/Admin.aspx.cs
+++ b/src/ChatBot/Admin/Admin.aspx.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Data.SQLite;
 using System.Text;
+using System.Web.UI;
 
 namespace ChatBot.Admin
 {

--- a/src/ChatBot/ChatBot.csproj
+++ b/src/ChatBot/ChatBot.csproj
@@ -5,6 +5,9 @@
   <ItemGroup>
     <!-- Allow building against .NET Framework reference assemblies on any OS -->
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" PrivateAssets="all" />
+    <!-- Explicitly reference System.Web to resolve WebForms types when building
+         against reference assemblies on non-Windows hosts -->
+    <Reference Include="System.Web" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.115" />
     <PackageReference Include="Google.Apis.Auth" Version="1.60.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- fix compile errors by explicitly referencing System.Web
- clean up Admin page namespace usage
- refresh project plan and deep dive report with current analysis
- document changes in changelog

## Testing
- `dotnet test` *(fails: command not found)*