### PR TITLE
Fix build refs and update docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,3 +3,6 @@
 ## [Unreleased]
 - Fixed naming conflict in `Chat.aspx` that prevented build by renaming the response `<pre>` element to `JsonResponse` and updating the code-behind.
 - Attempted to build the project but `dotnet` and `msbuild` tools were unavailable in the environment.
+- Added explicit `System.Web` reference so the WebForms project compiles with reference assemblies.
+- Updated documentation with revised project plan and deep dive analysis.
+- Enabled C# 8 syntax by specifying `LangVersion` in project files.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -36,6 +36,10 @@ The application follows SOLID principles with small classes:
 - Include anti-forgery tokens on all admin forms to mitigate CSRF attacks.
 - Centralize HTTP calls via `HttpClient` instances managed by dependency
   injection to improve testability and performance.
+- Add explicit references to `System.Web` so the project builds using
+  cross-platform reference assemblies.
+- Set `<LangVersion>8.0</LangVersion>` so modern C# syntax like `using var`
+  works when building with .NET Framework reference assemblies.
 
 ## Folder Structure
 

--- a/src/ChatBot/Admin/Admin.aspx.cs
+++ b/src/ChatBot/Admin/Admin.aspx.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Data.SQLite;
 using System.Text;
+using System.Web.UI;
 
 namespace ChatBot.Admin
 {

--- a/src/ChatBot/ChatBot.csproj
+++ b/src/ChatBot/ChatBot.csproj
@@ -1,10 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
+    <!-- Enable modern C# syntax such as 'using var' on .NET Framework -->
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Allow building against .NET Framework reference assemblies on any OS -->
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" PrivateAssets="all" />
+    <!-- Explicitly reference System.Web to resolve WebForms types when building
+         against reference assemblies on non-Windows hosts -->
+    <Reference Include="System.Web" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.115" />
     <PackageReference Include="Google.Apis.Auth" Version="1.60.0" />
   </ItemGroup>

--- a/tests/ChatBot.Tests.csproj
+++ b/tests/ChatBot.Tests.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <IsPackable>false</IsPackable>
+    <!-- Use modern C# syntax in unit tests -->
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Use reference assemblies so tests build on non-Windows machines -->


### PR DESCRIPTION
## Summary
- fix compile errors by explicitly referencing System.Web
- clean up Admin page namespace usage
- enable C# 8 language version
- refresh project plan and deep dive report with current analysis
- document changes in changelog

## Testing
- `dotnet test` *(fails: command not found)*