### PR TITLE
Add missing designer files for WebForms pages

### DIFF
--- a/src/ChatBot/Admin/Admin.aspx.designer.cs
+++ b/src/ChatBot/Admin/Admin.aspx.designer.cs
@@ -1,0 +1,13 @@
+namespace ChatBot.Admin
+{
+    public partial class Admin
+    {
+        protected global::System.Web.UI.WebControls.TextBox ApiKey;
+        protected global::System.Web.UI.WebControls.TextBox Model;
+        protected global::System.Web.UI.WebControls.TextBox GoogleClientId;
+        protected global::System.Web.UI.WebControls.TextBox GoogleClientSecret;
+        protected global::System.Web.UI.WebControls.TextBox AdminUser;
+        protected global::System.Web.UI.WebControls.TextBox AdminPassword;
+        protected global::System.Web.UI.WebControls.Button SaveButton;
+    }
+}

--- a/src/ChatBot/Chat/Chat.aspx.designer.cs
+++ b/src/ChatBot/Chat/Chat.aspx.designer.cs
@@ -1,0 +1,9 @@
+namespace ChatBot.Chat
+{
+    public partial class ChatPage
+    {
+        protected global::System.Web.UI.WebControls.TextBox UserMessage;
+        protected global::System.Web.UI.WebControls.Button SendButton;
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl JsonResponse;
+    }
+}

--- a/src/ChatBot/Debug/Debug.aspx.designer.cs
+++ b/src/ChatBot/Debug/Debug.aspx.designer.cs
@@ -1,0 +1,7 @@
+namespace ChatBot.Debug
+{
+    public partial class DebugPage
+    {
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl Logs;
+    }
+}


### PR DESCRIPTION
## Summary
- add ASP.NET designer files for Admin, Chat, and Debug pages

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*